### PR TITLE
Modified getPublicKeys endpoint

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -108,17 +108,20 @@ func (h *handler) handleGetPublicKeys() handlerWithUserID {
 		pubKeys := make([]string, 0)
 
 		if len(userIDs) == 0 {
-			h.jsonError(w, Error{Message: "public key doesn't exists", StatusCode: http.StatusNoContent})
+			h.jsonError(w, Error{Message: "User id array is empty", StatusCode: http.StatusNoContent})
 			return
 		}
 
 		for _, userID := range userIDs {
 			pubKey, err := h.an.GetPublicKey(userID)
-			if err != nil || pubKey == nil {
-				h.jsonError(w, Error{Message: "public key doesn't exists", StatusCode: http.StatusNoContent})
-				return
+			if err == nil && pubKey != nil {
+				pubKeys = append(pubKeys, pubKey.String())
 			}
-			pubKeys = append(pubKeys, pubKey.String())
+		}
+
+		if len(pubKeys) == 0 {
+			h.jsonError(w, Error{Message: "No public keys were found for given users", StatusCode: http.StatusNoContent})
+			return
 		}
 
 		h.respondWithJSON(w, response{PublicKeys: pubKeys})

--- a/webapp/__mocks__/Client.js
+++ b/webapp/__mocks__/Client.js
@@ -1,6 +1,6 @@
 
 const Client = {
-    retrievePublicKey: jest.fn(async () => {
+    retrievePublicKeys: jest.fn(async () => {
         return Promise.resolve({public_keys: []});
     }),
     getProfilesInChannel: jest.fn(async () => {

--- a/webapp/src/api_client/api_client.js
+++ b/webapp/src/api_client/api_client.js
@@ -23,7 +23,7 @@ export default class Client {
      *  @param {[string]} userIDs
      *  @returns {Object| null} response from api call
      */
-    retrievePublicKey = async (userIDs) => {
+    retrievePublicKeys = async (userIDs) => {
         let res = null;
         try {
             res = await this.doPost(`${this.url}/pub_keys`, {user_ids: userIDs});

--- a/webapp/src/hook/hook.js
+++ b/webapp/src/hook/hook.js
@@ -94,7 +94,7 @@ export default class Hooks {
             return user.id;
         });
 
-        const publicKeysb64 = await this.Client.retrievePublicKey(userIDs);
+        const publicKeysb64 = await this.Client.retrievePublicKeys(userIDs);
         if (publicKeysb64 === null) {
             return {success: false, message: ''};
         }
@@ -140,7 +140,7 @@ export default class Hooks {
             return (value.public_key === decrypter.PublicKey);
         });
         if (!myMessages || myMessages.length === 0) {
-            return '';
+            return 'Error: Message could not be decrypted!';
         }
         const encryptedAESKey = myMessages[0].aes_key;
         const encryptedMessage = myMessages[0].message;

--- a/webapp/src/hook/hook.js
+++ b/webapp/src/hook/hook.js
@@ -140,7 +140,7 @@ export default class Hooks {
             return (value.public_key === decrypter.PublicKey);
         });
         if (!myMessages || myMessages.length === 0) {
-            return 'Error: Message could not be decrypted!';
+            return 'Message could not be decrypted!';
         }
         const encryptedAESKey = myMessages[0].aes_key;
         const encryptedMessage = myMessages[0].message;

--- a/webapp/tests/hook.test.js
+++ b/webapp/tests/hook.test.js
@@ -15,7 +15,7 @@ test('hook encrypt/decrypt test', () => {
     const privateKey = new Key(null, key).PrivateKey;
     localStorage.setItem(LOCAL_STORAGE_KEY, privateKey);
 
-    Client.retrievePublicKey.mockImplementationOnce(() =>
+    Client.retrievePublicKeys.mockImplementationOnce(() =>
         Promise.resolve({public_keys: [publicKey]})
     );
 
@@ -36,7 +36,7 @@ test('hook encrypt/decrypt test', () => {
 });
 
 test('hook handlePostCommand error test', () => {
-    Client.retrievePublicKey.mockImplementationOnce(() =>
+    Client.retrievePublicKeys.mockImplementationOnce(() =>
         Promise.resolve({public_keys: null})
     );
 
@@ -50,7 +50,7 @@ test('hook handlePostCommand error test', () => {
 });
 
 test('hook handlePostCommand success test', () => {
-    Client.retrievePublicKey.mockImplementationOnce(() =>
+    Client.retrievePublicKeys.mockImplementationOnce(() =>
         Promise.resolve({public_keys: []})
     );
 
@@ -70,7 +70,7 @@ test('hook messageWillBePostedHook test', () => {
     const privateKey = new Key(null, key).PrivateKey;
     localStorage.setItem(LOCAL_STORAGE_KEY, privateKey);
 
-    Client.retrievePublicKey.mockImplementationOnce(() =>
+    Client.retrievePublicKeys.mockImplementationOnce(() =>
         Promise.resolve({public_keys: [publicKey]})
     );
 


### PR DESCRIPTION
messages can now be encrypted only for users that have keys, other users won't be able to decrypt said message